### PR TITLE
Reference keyset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /.idea/
 **/*.iml
 *.iml
+.classpath
+.vscode/
+.settings/

--- a/datajack-api/src/main/java/ru/sbtqa/tag/datajack/providers/AbstractDataProvider.java
+++ b/datajack-api/src/main/java/ru/sbtqa/tag/datajack/providers/AbstractDataProvider.java
@@ -31,8 +31,12 @@ public abstract class AbstractDataProvider implements TestDataProvider {
         } else if (getValue() != null) {
             return new HashSet<>();
         }
-
-        return basicObj.keySet();
+        if (isReference()) {
+            this.rootObj = null;
+            return getReference().getKeySet();
+        } else {
+            return basicObj.keySet();
+        }
     }
 
     public Collection<Object> getValues() throws DataException {

--- a/datajack-api/src/main/java/ru/sbtqa/tag/datajack/providers/AbstractDataProvider.java
+++ b/datajack-api/src/main/java/ru/sbtqa/tag/datajack/providers/AbstractDataProvider.java
@@ -33,7 +33,7 @@ public abstract class AbstractDataProvider implements TestDataProvider {
         }
         if (isReference()) {
             this.rootObj = null;
-            return getReference().getKeySet();
+            return getReference().toMap().keySet();
         } else {
             return basicObj.keySet();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -162,20 +162,20 @@
           <basedir>${project.basedir}</basedir>
         </configuration>
       </plugin>
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-gpg-plugin</artifactId>-->
-        <!--<version>${maven.gpg.plugin.version}</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<id>sign-artifacts</id>-->
-            <!--<phase>verify</phase>-->
-            <!--<goals>-->
-              <!--<goal>sign</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
-      <!--</plugin>-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>${maven.gpg.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -162,20 +162,20 @@
           <basedir>${project.basedir}</basedir>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>${maven.gpg.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-gpg-plugin</artifactId>-->
+        <!--<version>${maven.gpg.plugin.version}</version>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<id>sign-artifacts</id>-->
+            <!--<phase>verify</phase>-->
+            <!--<goals>-->
+              <!--<goal>sign</goal>-->
+            <!--</goals>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
     </plugins>
   </build>
 </project>

--- a/providers/excel-provider/src/test/java/ru/sbtqa/tag/datajack/providers/ExcelDataTest.java
+++ b/providers/excel-provider/src/test/java/ru/sbtqa/tag/datajack/providers/ExcelDataTest.java
@@ -48,6 +48,21 @@ public class ExcelDataTest {
     }
 
     @Test
+    public void getDeepReferenceTest() throws DataException {
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        testDataProvider.applyGenerator(SampleDataGensCallback.class);
+
+        String deepReferenceValue = testDataProvider.get("Common.ref object data.refToAnother").getValue();
+        String shortReferenceValue = testDataProvider.fromCollection("DataBlocks").get("NewObject.refToAnother").getValue();
+        String shortValue = testDataProvider.fromCollection("DataBlocks").get("AnotherObject").get("anotherValue").getValue();
+        String shortComplexValue = testDataProvider.fromCollection("DataBlocks").get("AnotherObject.anotherValue").getValue();
+
+        assertEquals("Deep reference isn't equal direct value", shortValue, deepReferenceValue);
+        assertEquals("Short reference isn't equal direct value", shortValue, shortReferenceValue);
+        assertEquals("Short complex value isn't equal direct value", shortValue, shortComplexValue);
+    }
+
+    @Test
     public void valuePathTest() throws DataException, IOException, InvalidFormatException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         assertEquals("justSomeTestId",

--- a/providers/excel-provider/src/test/java/ru/sbtqa/tag/datajack/providers/ExcelDataTest.java
+++ b/providers/excel-provider/src/test/java/ru/sbtqa/tag/datajack/providers/ExcelDataTest.java
@@ -34,14 +34,14 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void isReferenceTest() throws DataException, IOException, InvalidFormatException {
+    public void isReferenceTest() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         assertTrue("Value is not reference",
                 testDataProvider.get("Common.linkWithValue").isReference());
     }
 
     @Test
-    public void getReferenceTest() throws DataException, IOException, InvalidFormatException {
+    public void getReferenceTest() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         assertEquals("value",
                 testDataProvider.get("Common.linkWithValue").getValue());
@@ -63,14 +63,14 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void valuePathTest() throws DataException, IOException, InvalidFormatException {
+    public void valuePathTest() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         assertEquals("justSomeTestId",
                 testDataProvider.get("Common").get("id").getValue());
     }
 
     @Test
-    public void getFromAnotherCollectionTest() throws DataException, IOException, InvalidFormatException {
+    public void getFromAnotherCollectionTest() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         assertEquals("HELLO WORLD",
                 testDataProvider.fromCollection("DataBlocks").
@@ -78,7 +78,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void getNotValuedValueTest() throws DataException, IOException, InvalidFormatException {
+    public void getNotValuedValueTest() throws DataException {
         // TODO: 02.09.2016 is that r'ly actual for xls? Looks like not, cus all values there are strings
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         assertEquals("20.91",
@@ -86,7 +86,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void failWithWrongPath() throws DataException, IOException, InvalidFormatException {
+    public void failWithWrongPath() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         String wrongPath = "Common.password.paww";
         expectDataExceptions
@@ -99,7 +99,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void failWithWrongGetGetPath() throws DataException, IOException, InvalidFormatException {
+    public void failWithWrongGetGetPath() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         String wrongPath = "Common.password.paww";
         expectDataExceptions
@@ -109,7 +109,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void failWithCyclicReference() throws DataException, IOException, InvalidFormatException {
+    public void failWithCyclicReference() throws DataException {
         String cyclicPath = "Common.cyclic";
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         String cyclicObject = "{ \"value\" : { \"sheetName\" : \"DataBlocks\", "
@@ -122,7 +122,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void genDataSameCollectionTest() throws DataException, IOException, InvalidFormatException {
+    public void genDataSameCollectionTest() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         String genGenOrigin = testDataProvider.get("Uncommon.reftestGen").getValue();
@@ -133,7 +133,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void genDataDifferentCollections() throws DataException, IOException, InvalidFormatException {
+    public void genDataDifferentCollections() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         String genGenOrgigin = testDataProvider.get("Common.gendata").getValue();
@@ -142,7 +142,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void genDataDifferentCollectionsReference() throws DataException, IOException, InvalidFormatException {
+    public void genDataDifferentCollectionsReference() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         String genGenOrgigin = testDataProvider.get("Common.gendata").getValue();
@@ -154,7 +154,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void getRefAsObject() throws DataException, IOException, InvalidFormatException {
+    public void getRefAsObject() throws DataException {
         TestDataProvider originalProvider = new ExcelDataProvider(this.excellDataPath, "DataBlocks").get("NewObject");
         TestDataProvider referencedProvider = new ExcelDataProvider(this.excellDataPath, collectionName).
                 get("Common.ref object data").getReference();
@@ -162,7 +162,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void failRefAsObject() throws DataException, IOException, InvalidFormatException {
+    public void failRefAsObject() throws DataException {
         String path = "Common.id";
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
         expectDataExceptions.expect(ReferenceException.class);
@@ -172,7 +172,7 @@ public class ExcelDataTest {
     }
 
     @Test
-    public void generatorCacheDiffFiles() throws DataException, IOException, InvalidFormatException {
+    public void generatorCacheDiffFiles() throws DataException {
         TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, this.collectionName);
         TestDataProvider testDataProviderNew = new ExcelDataProvider("src/test/resources/excell/TestDataNew", this.collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);

--- a/providers/excel-provider/src/test/java/ru/sbtqa/tag/datajack/providers/ExcelDataTest.java
+++ b/providers/excel-provider/src/test/java/ru/sbtqa/tag/datajack/providers/ExcelDataTest.java
@@ -1,7 +1,6 @@
 package ru.sbtqa.tag.datajack.providers;
 
 import com.mongodb.BasicDBObject;
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,7 +12,6 @@ import ru.sbtqa.tag.datajack.exceptions.DataException;
 import ru.sbtqa.tag.datajack.exceptions.FieldNotFoundException;
 import ru.sbtqa.tag.datajack.exceptions.ReferenceException;
 
-import java.io.IOException;
 import java.util.*;
 
 import static java.lang.String.format;
@@ -23,7 +21,7 @@ import static ru.sbtqa.tag.datajack.callback.SampleDataCache.getCache;
 
 public class ExcelDataTest {
 
-    private final String excellDataPath = "src/test/resources/excell/TestData";
+    private final String excelDataPath = "src/test/resources/excell/TestData";
     private final String collectionName = "Tests";
     @Rule
     public ExpectedException expectDataExceptions = none();
@@ -35,21 +33,21 @@ public class ExcelDataTest {
 
     @Test
     public void isReferenceTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         assertTrue("Value is not reference",
                 testDataProvider.get("Common.linkWithValue").isReference());
     }
 
     @Test
     public void getReferenceTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         assertEquals("value",
                 testDataProvider.get("Common.linkWithValue").getValue());
     }
 
     @Test
     public void getDeepReferenceTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
 
         String deepReferenceValue = testDataProvider.get("Common.ref object data.refToAnother").getValue();
@@ -64,14 +62,14 @@ public class ExcelDataTest {
 
     @Test
     public void valuePathTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         assertEquals("justSomeTestId",
                 testDataProvider.get("Common").get("id").getValue());
     }
 
     @Test
     public void getFromAnotherCollectionTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         assertEquals("HELLO WORLD",
                 testDataProvider.fromCollection("DataBlocks").
                         get("AnotherObject").get("anotherValue").getValue());
@@ -80,14 +78,14 @@ public class ExcelDataTest {
     @Test
     public void getNotValuedValueTest() throws DataException {
         // TODO: 02.09.2016 is that r'ly actual for xls? Looks like not, cus all values there are strings
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         assertEquals("20.91",
                 testDataProvider.get("Common.price").getValue());
     }
 
     @Test
     public void failWithWrongPath() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         String wrongPath = "Common.password.paww";
         expectDataExceptions
                 .expect(FieldNotFoundException.class
@@ -100,7 +98,7 @@ public class ExcelDataTest {
 
     @Test
     public void failWithWrongGetGetPath() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         String wrongPath = "Common.password.paww";
         expectDataExceptions
                 .expect(FieldNotFoundException.class);
@@ -111,7 +109,7 @@ public class ExcelDataTest {
     @Test
     public void failWithCyclicReference() throws DataException {
         String cyclicPath = "Common.cyclic";
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         String cyclicObject = "{ \"value\" : { \"sheetName\" : \"DataBlocks\", "
                 + "\"path\" : \"AnotherObject.cyclicRef\" }";
         expectDataExceptions
@@ -123,7 +121,7 @@ public class ExcelDataTest {
 
     @Test
     public void genDataSameCollectionTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         String genGenOrigin = testDataProvider.get("Uncommon.reftestGen").getValue();
         assertFalse("Generator is not applied", genGenOrigin.contains("generate:"));
@@ -134,7 +132,7 @@ public class ExcelDataTest {
 
     @Test
     public void genDataDifferentCollections() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         String genGenOrgigin = testDataProvider.get("Common.gendata").getValue();
         assertFalse("Generator is not applied", genGenOrgigin.contains("generate:"));
@@ -143,7 +141,7 @@ public class ExcelDataTest {
 
     @Test
     public void genDataDifferentCollectionsReference() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         String genGenOrgigin = testDataProvider.get("Common.gendata").getValue();
         assertFalse("Generator is not applied", genGenOrgigin.contains("generate:"));
@@ -155,8 +153,8 @@ public class ExcelDataTest {
 
     @Test
     public void getRefAsObject() throws DataException {
-        TestDataProvider originalProvider = new ExcelDataProvider(this.excellDataPath, "DataBlocks").get("NewObject");
-        TestDataProvider referencedProvider = new ExcelDataProvider(this.excellDataPath, collectionName).
+        TestDataProvider originalProvider = new ExcelDataProvider(this.excelDataPath, "DataBlocks").get("NewObject");
+        TestDataProvider referencedProvider = new ExcelDataProvider(this.excelDataPath, collectionName).
                 get("Common.ref object data").getReference();
         assertEquals(originalProvider.toString(), referencedProvider.toString());
     }
@@ -164,7 +162,7 @@ public class ExcelDataTest {
     @Test
     public void failRefAsObject() throws DataException {
         String path = "Common.id";
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         expectDataExceptions.expect(ReferenceException.class);
         expectDataExceptions.expectMessage(String.format("There is no reference in '%s.%s'. Collection '%s'",
                 collectionName, path, collectionName));
@@ -173,7 +171,7 @@ public class ExcelDataTest {
 
     @Test
     public void generatorCacheDiffFiles() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, this.collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, this.collectionName);
         TestDataProvider testDataProviderNew = new ExcelDataProvider("src/test/resources/excell/TestDataNew", this.collectionName);
         testDataProvider.applyGenerator(SampleDataGensCallback.class);
         testDataProviderNew.applyGenerator(SampleDataGensCallback.class);
@@ -182,7 +180,7 @@ public class ExcelDataTest {
 
     @Test
     public void toMapTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         Object supposedToBeMap = testDataProvider.toMap();
 
         assertTrue("Type of return value toMap() is not Map", supposedToBeMap instanceof Map);
@@ -192,7 +190,7 @@ public class ExcelDataTest {
 
     @Test
     public void getKeySetTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         Object supposedToBeSet = testDataProvider.getKeySet();
 
         assertTrue("Type of return value getKeySet() is not Set", supposedToBeSet instanceof Set);
@@ -202,7 +200,7 @@ public class ExcelDataTest {
 
     @Test
     public void emptyKeySetForValueTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         Object supposedToBeSet = testDataProvider.get("Common.price").getKeySet();
 
         assertTrue("Type of return value getKeySet() is not Set", supposedToBeSet instanceof Set);
@@ -212,7 +210,7 @@ public class ExcelDataTest {
 
     @Test
     public void getValuesTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         Object rawValues = testDataProvider.getValues();
 
         assertTrue("Type of return value getValues() is not Collection", rawValues instanceof Collection);
@@ -222,7 +220,7 @@ public class ExcelDataTest {
 
     @Test
     public void getEmptySelfTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName);
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName);
         TestDataProvider origin = testDataProvider.get("Common");
         TestDataProvider self = origin.get("");
 
@@ -231,7 +229,7 @@ public class ExcelDataTest {
 
     @Test
     public void getStringValuesTest() throws DataException {
-        TestDataProvider testDataProvider = new ExcelDataProvider(this.excellDataPath, collectionName).get("MapTests");
+        TestDataProvider testDataProvider = new ExcelDataProvider(this.excelDataPath, collectionName).get("MapTests");
         Object stringValues = testDataProvider.getStringValues();
 
         assertTrue("Type of return value getStringValues() is not List", stringValues instanceof List);

--- a/providers/json-provider/src/main/java/ru/sbtqa/tag/datajack/providers/json/JsonDataProvider.java
+++ b/providers/json-provider/src/main/java/ru/sbtqa/tag/datajack/providers/json/JsonDataProvider.java
@@ -108,6 +108,18 @@ public class JsonDataProvider extends AbstractDataProvider {
      *
      * @param <T>            Overrider type
      * @param testDataFolder path to data folder
+     * @param collectionName file name
+     * @return
+     */
+    protected <T extends JsonDataProvider> T privateInit(String testDataFolder, String collectionName) throws DataException {
+        return (T) new JsonDataProvider(testDataFolder, collectionName, extension);
+    }
+
+    /**
+     * Internal use only for provider overriding purposes
+     *
+     * @param <T>            Overrider type
+     * @param testDataFolder path to data folder
      * @param obj            Basic object
      * @param collectionName file name
      * @param way            complex path to value
@@ -149,7 +161,7 @@ public class JsonDataProvider extends AbstractDataProvider {
 
     }
 
-    private TestDataProvider getSimple(String key) throws FieldNotFoundException, DataException {
+    private TestDataProvider getSimple(String key) throws DataException {
         Object result;
 
         if (isArray(key)) {
@@ -206,7 +218,7 @@ public class JsonDataProvider extends AbstractDataProvider {
             if (isReference(basicObject)) {
                 String collection = ((BasicDBObject) basicObject.get("value")).getString("collection");
                 String path = ((BasicDBObject) basicObject.get("value")).getString("path");
-                TestDataProvider dataProvider = new JsonDataProvider(this.testDataFolder, collection).get(path);
+                TestDataProvider dataProvider = privateInit(this.testDataFolder, collection).get(path);
                 basicObject = ((JsonDataProvider) dataProvider).basicObj;
             }
 

--- a/providers/json-provider/src/test/java/ru/sbtqa/tag/datajack/providers/json/JsonDataTest.java
+++ b/providers/json-provider/src/test/java/ru/sbtqa/tag/datajack/providers/json/JsonDataTest.java
@@ -97,21 +97,28 @@ public class JsonDataTest {
     }
 
     @Test
+    public void getDeepReferenceTest() throws DataException {
+        String collectionName = "Tests";
+        TestDataProvider testDataProvider = new JsonDataProvider(JSON_DATA_PATH, collectionName);
+        testDataProvider.applyGenerator(SampleDataGensCallback.class);
+
+        String deepReferenceValue = testDataProvider.get("Common.ref object data.gendata reference").getValue();
+        String shortReferenceValue = testDataProvider.fromCollection("DataBlocks").get("Common.gendata reference").getValue();
+        String shortComplexValue = testDataProvider.fromCollection("DataBlocks").get("Common.gen gen.gendata").getValue();
+        String shortValue = testDataProvider.fromCollection("DataBlocks").get("Common").get("gen gen").get("gendata").getValue();
+
+        assertEquals("Deep reference isn't equal direct value", shortValue, deepReferenceValue);
+        assertEquals("Short reference isn't equal direct value", shortValue, shortReferenceValue);
+        assertEquals("Short complex value isn't equal direct value", shortValue, shortComplexValue);
+    }
+
+    @Test
     public void isReferenceTest() throws DataException {
         String collectionName = "DataBlocks";
         TestDataProvider testDataProvider = new JsonDataProvider(JSON_DATA_PATH, collectionName);
 
         assertTrue("This isn't reference",
                 testDataProvider.get("Common.password2").isReference());
-    }
-
-    @Test
-    public void valuePathTest() throws DataException {
-        String collectionName = "DataBlocks";
-        TestDataProvider testDataProvider = new JsonDataProvider(JSON_DATA_PATH, collectionName);
-
-        assertEquals("Params Group 1.password",
-                testDataProvider.get("Common").get("password2.value.path").getValue());
     }
 
     @Test

--- a/providers/mongo-provider/src/main/java/ru/sbtqa/tag/datajack/providers/MongoDataProvider.java
+++ b/providers/mongo-provider/src/main/java/ru/sbtqa/tag/datajack/providers/MongoDataProvider.java
@@ -14,43 +14,84 @@ import ru.sbtqa.tag.datajack.exceptions.*;
 import static com.mongodb.BasicDBObject.parse;
 import static com.mongodb.QueryBuilder.start;
 import static java.lang.String.format;
+import static org.apache.commons.io.FileUtils.readFileToString;
 
 public class MongoDataProvider extends AbstractDataProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDataProvider.class);
+    protected String collectionName;
     private static final String REF_ID_TPL = "refId";
     private final DB db;
-    private DBCollection coll;
+    private DBCollection collection;
+
 
     /**
      * Initialize new data object
      *
-     * @param db   Database object
-     * @param coll Collection
+     * @param db Database object
      * @throws DataException if no collection or its empty
      */
-    public MongoDataProvider(DB db, String coll) throws DataException {
+    public MongoDataProvider(DB db, String collectionName) throws DataException {
         this.db = db;
-        this.coll = this.db.getCollection(coll);
-        if (this.coll.count() == 0) {
-            throw new CollectionNotfoundException(String.format("There is no \"%s\" collection or it's empty", coll));
+        this.collection = this.db.getCollection(collectionName);
+        if (this.collection.count() == 0) {
+            throw new CollectionNotfoundException(String.format("There is no \"%s\" collection or it's empty", collectionName));
         }
-        this.way = coll;
+        this.basicObj = (BasicDBObject) collection.find().sort(new BasicDBObject("_id",-1)).limit(1).next();
+        this.way = collectionName;
+        this.path = collectionName;
+        this.collectionName = collectionName;
 
     }
 
-    private MongoDataProvider(DB db, BasicDBObject obj, String way) {
+    /**
+     * Initialize new data object
+     *
+     * @param db Database object
+     * @throws DataException if no collection or its empty
+     */
+    public MongoDataProvider(DB db, String collectionName, String refId) throws DataException {
+        this.db = db;
+        this.collection = this.db.getCollection(collectionName);
+        if (this.collection.count() == 0) {
+            throw new CollectionNotfoundException(String.format("There is no \"%s\" collection or it's empty", collectionName));
+        }
+        this.basicObj = (BasicDBObject) this.collection.findOne(new BasicDBObject("_id", new ObjectId(refId)));
+        this.way = collectionName;
+        this.collectionName = collectionName;
+        this.path="";
+
+    }
+
+    /**
+     * Internal use only
+     *
+     * @param obj            basic object
+     * @param collectionName file name
+     * @param way            complex path to value
+     */
+    protected MongoDataProvider(DB db, BasicDBObject obj, String collectionName, String way) {
         this.db = db;
         this.basicObj = obj;
         this.way = way;
+        this.collectionName = collectionName;
     }
 
+    public BasicDBObject getBasicDBObject() {
+        return this.basicObj;
+    }
+
+    public static boolean isArray(String key) {
+        return key.matches("(.+\\[\\d+\\])");
+    }
+
+
     @Override
-    public MongoDataProvider fromCollection(String collectionName) throws DataException {
-        MongoDataProvider dataProvider = new MongoDataProvider(this.db, collectionName);
+    public MongoDataProvider fromCollection(String collName) throws DataException {
+
+        MongoDataProvider dataProvider = new MongoDataProvider(this.db, collName);
         dataProvider.applyGenerator(this.callback);
         return dataProvider;
-
     }
 
     /**
@@ -60,9 +101,16 @@ public class MongoDataProvider extends AbstractDataProvider {
      * @throws DataException if no collection or its empty
      */
     public MongoDataProvider fromCollection(String collectionName, String refId) throws DataException {
-        this.coll = db.getCollection(collectionName);
-        DBObject referenceDocument = this.coll.findOne(new BasicDBObject("_id", new ObjectId(refId)));
-        MongoDataProvider dataProvider = new MongoDataProvider(this.db, collectionName);
+        this.collection = db.getCollection(collectionName);
+
+        ObjectId id= new ObjectId(refId);
+        BasicDBObject obj = new BasicDBObject();
+        obj.append("_id", id);
+        BasicDBObject query = new BasicDBObject();
+        query.putAll((BSONObject)query);
+        DBObject referenceDocument = collection.findOne(query);
+
+        MongoDataProvider dataProvider = new MongoDataProvider(this.db, collectionName, refId);
         dataProvider.basicObj = (BasicDBObject) referenceDocument;
         dataProvider.path = refId + "." + collectionName;
         dataProvider.applyGenerator(this.callback);
@@ -71,68 +119,102 @@ public class MongoDataProvider extends AbstractDataProvider {
     }
 
     @Override
-    public MongoDataProvider get(String key) throws DataException {
+    public TestDataProvider get(String key) throws DataException {
         if (key.isEmpty()) {
             return this;
         }
         this.way = key;
-        String documentId = "HERE IS MUST BE ID";
-        MongoDataProvider dataProvider;
-        if (this.basicObj == null) {
+        return key.contains(".") ? getComplex(key) : getSimple(key);
 
-            try (DBCursor cursor = coll.find(start(key).exists(true).get()).limit(1).sort((DBObject) parse("{$natural:-1}"))) {
-                if (cursor.hasNext()) {
-                    this.basicObj = (BasicDBObject) cursor.next();
-                    documentId = this.basicObj.getString("_id");
-                } else {
-                    throw new FieldNotFoundException(format("Collection \"%s\" doesn't contain \"%s\" field on path \"%s\"",
-                            this.coll.getName(), key.split("[.]")[key.split("[.]").length - 1], key));
-                }
-            }
-        }
-        if (key.contains(".")) {
-            String[] keys = key.split("[.]");
-            BasicDBObject basicO = this.basicObj;
-            for (String partialKey : keys) {
-                if (!(basicO.get(partialKey) instanceof BasicDBObject)) {
-                    break;
-                }
-                basicO = (BasicDBObject) basicO.get(partialKey);
-            }
+    }
 
-            dataProvider = new MongoDataProvider(this.db, basicO, this.way);
+    private TestDataProvider getSimple(String key) throws DataException {
+        Object result;
 
-            if (this.path == null || (this.coll != null && this.path.equals(this.coll.getName()))) {
-                this.path = documentId + "." + this.coll.getName();
-            } else if (this.coll == null) {
-                this.path = documentId + "." + this.path;
+        if (isArray(key)) {
+            result = parseArray(basicObj, key);
+        } else {
+
+            if (!basicObj.containsField(key)) {
+                throw new FieldNotFoundException(format("Collection \"%s\" doesn't contain \"%s\" field in path \"%s\"",
+                        this.collectionName, key, this.path));
             }
-            dataProvider.applyGenerator(this.callback);
-            dataProvider.coll = coll;
-            dataProvider.setRootObj(this.rootObj, this.path + "." + key);
-            return dataProvider;
+            result = this.basicObj.get(key);
         }
-        if (!basicObj.containsField(key)) {
-            throw new FieldNotFoundException(format("Collection \"%s\" doesn't contain \"%s\" field in path \"%s\"",
-                    this.coll.getName(), key, this.path));
-        }
-        Object result = basicObj.get(key);
         if (!(result instanceof BasicDBObject)) {
             result = new BasicDBObject(key, result);
         }
-
-        dataProvider = new MongoDataProvider(this.db, (BasicDBObject) result, this.way);
+        MongoDataProvider dataProvider = new MongoDataProvider(db, (BasicDBObject) result, this.collectionName, this.way);
+        dataProvider.applyGenerator(this.callback);
 
         String rootObjValue;
         if (this.path != null) {
             rootObjValue = this.path + "." + key;
         } else {
-            rootObjValue = this.coll.getName() + "." + key;
+            rootObjValue = this.collectionName + "." + key;
         }
-        dataProvider.applyGenerator(this.callback);
-        dataProvider.coll = coll;
         dataProvider.setRootObj(this.rootObj, rootObjValue);
+        if (dataProvider.isReference()) {
+            return dataProvider.getReference();
+        }
         return dataProvider;
+    }
+
+    private TestDataProvider getComplex(String key) throws DataException {
+
+        MongoDataProvider dataProvider = new MongoDataProvider(db, parseComplexDBObject(key), this.collectionName, this.way);
+        dataProvider.applyGenerator(this.callback);
+        dataProvider.setRootObj(this.rootObj, this.collectionName + "." + key);
+
+        return dataProvider;
+    }
+
+    private BasicDBObject parseComplexDBObject(String key) throws DataException {
+        String[] keys = key.split("[.]");
+        StringBuilder partialBuilt = new StringBuilder();
+        BasicDBObject basicObject = this.basicObj;
+
+        for (String partialKey : keys) {
+            partialBuilt.append(partialKey);
+
+            if (isArray(partialKey)) {
+                basicObject = (BasicDBObject) parseArray(basicObject, partialKey);
+                continue;
+            }
+
+            if (isReference(basicObject)) {
+                String collection = ((BasicDBObject) basicObject.get("value")).getString("collection");
+                String path = ((BasicDBObject) basicObject.get("value")).getString("path");
+                TestDataProvider dataProvider = new MongoDataProvider(db, collection).get(path);
+                basicObject = ((MongoDataProvider) dataProvider).basicObj;
+            }
+
+            if (!(basicObject.get(partialKey) instanceof BasicDBObject)) {
+                if (null == basicObject.get(partialKey)) {
+                    throw new FieldNotFoundException(format("Collection \"%s\" doesn't contain \"%s\" field on path \"%s\"",
+                            this.collectionName, partialKey, partialBuilt.toString()));
+                }
+                break;
+            }
+            basicObject = (BasicDBObject) basicObject.get(partialKey);
+            partialBuilt.append(".");
+        }
+        return basicObject;
+    }
+
+    private Object parseArray(BasicDBObject basicO, String key) throws DataException {
+        if (!isArray(key)) {
+            throw new DataException(String.format("%s.%s is not an array!", this.collectionName, key));
+        }
+        String arrayKey = key.split("\\[")[0];
+        String arrayIndex = key.split("\\[")[1].split("\\]")[0];
+        Object listCandidate = basicO.get(arrayKey);
+
+        if (!(listCandidate instanceof BasicDBList)) {
+            throw new DataException(String.format("%s.%s is not an array!", this.collectionName, key));
+        }
+
+        return ((BasicDBList) listCandidate).get(arrayIndex);
     }
 
     @Override
@@ -144,17 +226,8 @@ public class MongoDataProvider extends AbstractDataProvider {
     }
 
     private void setRootObj(BasicDBObject obj, String path) {
-        if (obj != null && obj.containsField(VALUE_TPL)
-                && ((BasicDBObject) obj.get(VALUE_TPL)).containsField(REF_ID_TPL)) {
-            String colName = "";
-            if (this.coll != null) {
-                colName = "." + this.coll.getName();
-            }
-            this.path = ((BasicBSONObject) obj.get(VALUE_TPL)).getString(REF_ID_TPL) + colName + "." + this.way;
-        } else {
-            this.path = path;
-        }
         this.rootObj = obj;
+        this.path = path;
     }
 
     @Override
@@ -165,12 +238,11 @@ public class MongoDataProvider extends AbstractDataProvider {
             LOG.debug("Reference not found", e);
             String result = this.basicObj.getString(VALUE_TPL);
             if (result == null) {
-                if (this.way.contains(".")) {
+                if (this.way != null && this.way.contains(".")) {
                     this.way = this.way.split("[.]")[this.way.split("[.]").length - 1];
                 }
                 result = this.basicObj.getString(this.way);
             }
-
             if (this.callback != null) {
                 CallbackData generatorParams = new CallbackData(this.path, result);
                 Object callbackResult = null;
@@ -205,19 +277,12 @@ public class MongoDataProvider extends AbstractDataProvider {
             }
             String referencedCollection = ((BasicBSONObject) this.basicObj.get(VALUE_TPL)).getString(COLLECTION_TPL);
             this.path = ((BasicBSONObject) this.basicObj.get(VALUE_TPL)).getString("path");
-            MongoDataProvider reference;
-            if (((BSONObject) this.basicObj.get(VALUE_TPL)).containsField(REF_ID_TPL)) {
-                String refId = ((BasicBSONObject) this.basicObj.get(VALUE_TPL)).getString(REF_ID_TPL);
-                reference = this.fromCollection(referencedCollection, refId);
-            } else {
-                reference = this.fromCollection(referencedCollection);
-            }
-
-            reference.setRootObj(this.rootObj, referencedCollection);
+            MongoDataProvider reference = this.fromCollection(((BasicBSONObject) this.basicObj.get(VALUE_TPL)).getString(COLLECTION_TPL));
+            reference.setRootObj(this.rootObj, referencedCollection + "." + this.path);
             return reference.get(this.path);
         } else {
             throw new ReferenceException(String.format("There is no reference in \"%s\". Collection \"%s\"",
-                    this.path, this.coll.getName()));
+                    this.path, this.collectionName));
         }
     }
 
@@ -228,10 +293,18 @@ public class MongoDataProvider extends AbstractDataProvider {
 
     @Override
     public boolean isReference() throws DataException {
-        Object value = this.basicObj.get(VALUE_TPL);
+        Object value = this.basicObj.get("value");
         if (!(value instanceof BasicDBObject)) {
             return false;
         }
-        return ((BasicDBObject) value).containsField(COLLECTION_TPL) && ((BasicDBObject) value).containsField("path");
+        return ((BasicDBObject) value).containsField("collection") && ((BasicDBObject) value).containsField("path");
+    }
+
+    public boolean isReference(BasicDBObject basicDBObject) throws DataException {
+        Object value = basicDBObject.get("value");
+        if (!(value instanceof BasicDBObject)) {
+            return false;
+        }
+        return ((BasicDBObject) value).containsField("collection") && ((BasicDBObject) value).containsField("path");
     }
 }

--- a/providers/mongo-provider/src/test/java/ru/sbtqa/tag/datajack/providers/MongoDataTest.java
+++ b/providers/mongo-provider/src/test/java/ru/sbtqa/tag/datajack/providers/MongoDataTest.java
@@ -52,17 +52,27 @@ public class MongoDataTest {
     }
 
     @Test
+    public void getDeepReferenceTest() throws DataException {
+        String collectionName = "Tests";
+        TestDataProvider testDataProvider = new MongoDataProvider(mongoDb, collectionName);
+        testDataProvider.applyGenerator(SampleDataGensCallback.class);
+
+        String deepReferenceValue = testDataProvider.get("Common.ref object data.gendata reference").getValue();
+        String shortReferenceValue = testDataProvider.fromCollection("DataBlocks").get("Common.gendata reference").getValue();
+        String shortComplexValue = testDataProvider.fromCollection("DataBlocks").get("Common.gen gen.gendata").getValue();
+        String shortValue = testDataProvider.fromCollection("DataBlocks").get("Common").get("gen gen").get("gendata").getValue();
+
+        assertEquals("Deep reference isn't equal direct value", shortValue, deepReferenceValue);
+        assertEquals("Short reference isn't equal direct value", shortValue, shortReferenceValue);
+        assertEquals("Short complex value isn't equal direct value", shortValue, shortComplexValue);
+    }
+
+
+    @Test
     public void isReference() throws DataException {
         TestDataProvider testDataProvider = new MongoDataProvider(mongoDb, "DataBlocks");
         assertTrue("Value is not reference",
                 testDataProvider.get("Common.password2").isReference());
-    }
-
-    @Test
-    public void valuePath() throws DataException {
-        TestDataProvider testDataProvider = new MongoDataProvider(mongoDb, "DataBlocks");
-        assertEquals("Params Group 1.password",
-                testDataProvider.get("Common").get("password2.value.path").getValue());
     }
 
     @Test
@@ -220,7 +230,7 @@ public class MongoDataTest {
     @Test
     public void getRefAsObject() throws DataException {
         TestDataProvider originalProvider = new MongoDataProvider(mongoDb, "DataBlocks").
-                fromCollection("DataBlocks", "57a94a160a279ec293f61665").get("Common");
+                    fromCollection("DataBlocks", "57a94a160a279ec293f61665").get("Common");
         TestDataProvider referencedProvider = new MongoDataProvider(mongoDb, "Tests").
                 get("Common.ref object data").getReference();
         assertEquals(originalProvider.toString(), referencedProvider.toString());

--- a/providers/properties-provider/src/main/java/ru/sbtqa/tag/datajack/providers/properties/PropertiesDataProvider.java
+++ b/providers/properties-provider/src/main/java/ru/sbtqa/tag/datajack/providers/properties/PropertiesDataProvider.java
@@ -52,6 +52,11 @@ public class PropertiesDataProvider extends JsonDataProvider {
     }
 
     @Override
+    protected <T extends JsonDataProvider> T privateInit(String testDataFolder, String collectionName) throws DataException {
+        return (T) new PropertiesDataProvider(testDataFolder, collectionName, extension);
+    }
+
+    @Override
     protected <T extends JsonDataProvider> T privateInit(String testDataFolder, BasicDBObject obj, String collectionName, String way) {
         return (T) new PropertiesDataProvider(testDataFolder, obj, collectionName, way, extension);
     }

--- a/providers/properties-provider/src/test/java/ru/sbtqa/tag/datajack/providers/properties/PropertiesDataTest.java
+++ b/providers/properties-provider/src/test/java/ru/sbtqa/tag/datajack/providers/properties/PropertiesDataTest.java
@@ -101,6 +101,23 @@ public class PropertiesDataTest {
                 dataProvider.get("Common.password2").getValue());
     }
 
+
+    @Test
+    public void getDeepReferenceTest() throws DataException {
+        String collectionName = "Tests";
+        TestDataProvider dataProvider = new PropertiesDataProvider(this.propertiesDataPath, collectionName);
+        dataProvider.applyGenerator(SampleDataGensCallback.class);
+
+        String deepReferenceValue = dataProvider.get("Common.ref object data.gendata reference").getValue();
+        String shortReferenceValue = dataProvider.fromCollection("DataBlocks").get("Common.gendata reference").getValue();
+        String shortComplexValue = dataProvider.fromCollection("DataBlocks").get("Common.gen gen.gendata").getValue();
+        String shortValue = dataProvider.fromCollection("DataBlocks").get("Common").get("gen gen").get("gendata").getValue();
+
+        assertEquals("Deep reference isn't equal direct value", shortValue, deepReferenceValue);
+        assertEquals("Short reference isn't equal direct value", shortValue, shortReferenceValue);
+        assertEquals("Short complex value isn't equal direct value", shortValue, shortComplexValue);
+    }
+
     @Test
     public void isReferenceTest() throws DataException {
         String collectionName = "DataBlocks";
@@ -108,15 +125,6 @@ public class PropertiesDataTest {
 
         assertTrue("This isn't reference",
                 dataProvider.get("Common.password2").isReference());
-    }
-
-    @Test
-    public void valuePathTest() throws DataException {
-        String collectionName = "DataBlocks";
-        TestDataProvider dataProvider = new PropertiesDataProvider(this.propertiesDataPath, collectionName);
-
-        assertEquals("Params Group 1.password",
-                dataProvider.get("Common").get("password2.value.path").getValue());
     }
 
     @Test


### PR DESCRIPTION
- Now getKeySet pointed to reference returns reference's fields instead of reference not resolved object.

- Now it possible to automatically resolve references in complex paths i.e. get("Common.reference.reference_key.another_reference.another_reference_key") will works great.

All additional details you can see in tests.